### PR TITLE
[Update] actor create api

### DIFF
--- a/movies/views.py
+++ b/movies/views.py
@@ -111,24 +111,38 @@ class ActorDetailView(APIView):
     def post(self, request):
         try:
             data         = request.data
-            actor_name   = data['actor_name']
-            country_name = data['country_name']
+            name         = data['name']
             image_url    = data['image_url']
+            country_id   = data['country_id']
+            birth        = data['birth']
+            debut        = data['debut']
+            debut_year   = data['debut_year']
+            height       = data.get('height', 0)
+            weight       = data.get('weight', 0)
+            job_id_list  = data.getlist('job_id')
             
-            if Actor.objects.filter(name=actor_name):
+            if Actor.objects.filter(name=name, birth=birth):
                 return Response({'message': 'ALREADY_ACTOR'}, status=400)
             
             else:
-                country = Country.objects.get(name=country_name)
-
                 image_url = FileHander(s3_client).upload(image_url, 'image/actor')
-                image = Image.objects.create(image_url=image_url)
-            
-                Actor.objects.create(
-                    name    = actor_name,
-                    country = country,
-                    image   = image
+                image     = Image.objects.create(image_url=image_url)
+                
+                actor = Actor.objects.create(
+                    name       = name,
+                    image      = image,
+                    country    = Country.objects.get(id=country_id),
+                    birth      = birth,
+                    debut      = debut,
+                    debut_year = debut_year,
+                    height     = height,
+                    weight     = weight,
                 )
+                
+                ActorJob.objects.bulk_create([
+                    ActorJob(actor = actor,
+                             job   = Job.objects.get(id=job_id)
+                ) for job_id in job_id_list])
             
                 return Response({'message': 'CREATE_SUCCESS'}, status=201)
             


### PR DESCRIPTION
# 영화배우 데이터 생성 API

## 수정사항

1. 영화배우 직업 request data 형식 코드 수정
직업이 여러개 일수도 있는 점을 생각하여 코드를 수정 (ex. 김윤석 배우의 경우 배우이자 감독)
    - `'job_id': ['1', '2']` 형식으로 front에서 보내주면 actor_job 테이블 (actor 테이블과 job테이블의 중간테이블)의 데이터가 한꺼번에 생성되도록 구현
    - 직업이 한개일 경우 `'job_id': ['1']`
2. db에 이미 등록된 영화배우 등록시 예외처리 코드 수정
    - 기존 코드의 경우 배우의 이름만으로 중복여부를 판단했으나 생년월일도 추가